### PR TITLE
fix(users): don't use the MailSwitcher class

### DIFF
--- a/app/TeenQuotes/Newsletters/Console/UnsubscribeUsersCommand.php
+++ b/app/TeenQuotes/Newsletters/Console/UnsubscribeUsersCommand.php
@@ -94,7 +94,6 @@ class UnsubscribeUsersCommand extends ScheduledCommand {
 		$this->newslettersManager->deleteForUsers($allUsers);
 
 		// Send an email to each user to notice them
-		new MailSwitcher('smtp');
 		$nonActiveUsers->each(function($user)
 		{
 			// Log this info


### PR DESCRIPTION
Do not send emails to users through SMTP when unsubscribing
them from newsletters
